### PR TITLE
Add agent fan-out editor example

### DIFF
--- a/examples/workflow-editor-v2/src/components/Editor.tsx
+++ b/examples/workflow-editor-v2/src/components/Editor.tsx
@@ -1,0 +1,71 @@
+import React, { useMemo, useRef, useState, useEffect } from "react";
+import {
+  ReactFlow,
+  useNodesState,
+  useEdgesState,
+  useNodesInitialized,
+  NodeChange,
+  ReactFlowProvider,
+} from "@xyflow/react";
+import { nodeTypes } from "../nodes";
+import { buildGraph } from "../utils/parseWorkflow";
+import { useProvider } from "./Provider";
+import { useLayout } from "../utils/layout";
+
+export type Direction = "right" | "down";
+export interface EditorProps {
+  direction?: Direction;
+}
+
+export const Editor: React.FC<EditorProps> = ({ direction = "down" }) => (
+  <ReactFlowProvider>
+    <EditorInner direction={direction} />
+  </ReactFlowProvider>
+);
+
+const EditorInner: React.FC<EditorProps> = ({ direction = "down" }) => {
+  const { workflow } = useProvider();
+  const ref = useRef<HTMLDivElement>(null);
+  const nodesInitialized = useNodesInitialized();
+
+  const { nodes: initialNodes, edges: initialEdges } = useMemo(
+    () => buildGraph(workflow, direction),
+    [workflow, direction]
+  );
+
+  const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes);
+  const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
+
+  useLayout({
+    nodes,
+    edges,
+    width: ref.current?.offsetWidth ?? 0,
+    height: ref.current?.offsetHeight ?? 0,
+    direction,
+    setNodes,
+    setEdges,
+    nodesInitialized,
+    defaultNodeMeasure: undefined,
+  });
+
+  useEffect(() => {
+    const { nodes, edges } = buildGraph(workflow, direction);
+    setNodes(nodes);
+    setEdges(edges);
+  }, [workflow, direction]);
+
+  return (
+    <div ref={ref} className="wf-editor">
+      <ReactFlow
+        nodeTypes={nodeTypes}
+        nodes={nodes}
+        edges={edges}
+        onNodesChange={onNodesChange as (changes: NodeChange[]) => void}
+        onEdgesChange={onEdgesChange}
+        edgesFocusable={false}
+        edgesReconnectable={false}
+        proOptions={{ hideAttribution: true }}
+      />
+    </div>
+  );
+};

--- a/examples/workflow-editor-v2/src/components/Provider.tsx
+++ b/examples/workflow-editor-v2/src/components/Provider.tsx
@@ -1,0 +1,40 @@
+import React, { useContext, useState } from 'react';
+import { Workflow } from '../types';
+
+export interface ProviderProps {
+  workflow: Workflow;
+  onChange?: (w: Workflow) => void;
+}
+
+interface Ctx extends ProviderProps {
+  setWorkflow: (w: Workflow) => void;
+}
+
+const Context = React.createContext<Ctx | undefined>(undefined);
+
+export const Provider: React.FC<ProviderProps & { children: React.ReactNode }> = ({
+  workflow,
+  onChange,
+  children,
+}) => {
+  const [wf, setWf] = useState(workflow);
+
+  const setWorkflow = (w: Workflow) => {
+    setWf(w);
+    onChange?.(w);
+  };
+
+  return (
+    <Context.Provider value={{ workflow: wf, onChange, setWorkflow }}>
+      {children}
+    </Context.Provider>
+  );
+};
+
+export const useProvider = (): Ctx => {
+  const ctx = useContext(Context);
+  if (!ctx) throw new Error('useProvider must be used within Provider');
+  return ctx;
+};
+
+export const useWorkflow = () => useProvider().workflow;

--- a/examples/workflow-editor-v2/src/nodes/ActionBaseNode.tsx
+++ b/examples/workflow-editor-v2/src/nodes/ActionBaseNode.tsx
@@ -1,0 +1,67 @@
+import React from "react";
+import { Handle, Position } from "@xyflow/react";
+import { WorkflowActionBase, EmailAction, DelayAction, AgentAction, MCP, Memory, Storage } from "../types/actions";
+
+interface Props<T extends WorkflowActionBase> {
+  action: T;
+  children: React.ReactNode;
+  className?: string;
+}
+
+export const ActionBaseNode = <T extends WorkflowActionBase>({
+  action,
+  children,
+  className = "",
+}: Props<T>) => (
+  <div className={`wf-node wf-node-${action.kind} ${className}`.trim()}>
+    <Handle type="target" position={Position.Top} />
+    {children}
+    <Handle type="source" position={Position.Bottom} />
+  </div>
+);
+
+export const EmailNode: React.FC<{ action: EmailAction }> = ({ action }) => (
+  <ActionBaseNode action={action}>
+    <h4>📧 Email</h4>
+    <p>{action.to || "(no recipient)"}</p>
+  </ActionBaseNode>
+);
+
+export const DelayNode: React.FC<{ action: DelayAction }> = ({ action }) => (
+  <ActionBaseNode action={action}>
+    <h4>⏱ Delay</h4>
+    <p>{action.durationMs / 1000}s</p>
+  </ActionBaseNode>
+);
+
+export const AgentNode: React.FC<{ action: AgentAction }> = ({ action }) => (
+  <ActionBaseNode action={action} className="wf-node-agent">
+    <h4>🤖 Agent</h4>
+    <p>{action.name}</p>
+  </ActionBaseNode>
+);
+
+export const McpNode: React.FC<{ mcp: MCP }> = ({ mcp }) => (
+  <div className="wf-node wf-node-mcp">
+    <Handle type="target" position={Position.Top} />
+    <h4>MCP</h4>
+    <p>{mcp.name}</p>
+  </div>
+);
+
+export const MemoryNode: React.FC<{ memory: Memory }> = ({ memory }) => (
+  <div className="wf-node wf-node-memory">
+    <Handle type="target" position={Position.Top} />
+    <h4>🧠 Memory</h4>
+    <p>history: {memory.conversationHistory}</p>
+    <Handle type="source" position={Position.Bottom} />
+  </div>
+);
+
+export const StorageNode: React.FC<{ storage: Storage }> = ({ storage }) => (
+  <div className="wf-node wf-node-storage">
+    <Handle type="target" position={Position.Top} />
+    <h4>💾 Storage</h4>
+    <p>{storage.database}@{storage.endpoint}:{storage.port}</p>
+  </div>
+);

--- a/examples/workflow-editor-v2/src/nodes/BlankNode.tsx
+++ b/examples/workflow-editor-v2/src/nodes/BlankNode.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+import { Handle, Position } from "@xyflow/react";
+
+export const BlankNode: React.FC = () => (
+  <div className="wf-node wf-node-blank">
+    <Handle type="target" position={Position.Top} />
+    <Handle type="source" position={Position.Bottom} />
+  </div>
+);

--- a/examples/workflow-editor-v2/src/nodes/TriggerNode.tsx
+++ b/examples/workflow-editor-v2/src/nodes/TriggerNode.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import { Handle, Position } from "@xyflow/react";
+
+export const triggerNodeFactory = ({ data }: any) => {
+  const { trigger } = data;
+  return (
+    <div className="wf-node wf-node-trigger">
+      <Handle type="source" position={Position.Bottom} />
+      <h4>Trigger</h4>
+      <p>{trigger}</p>
+    </div>
+  );
+};

--- a/examples/workflow-editor-v2/src/nodes/index.ts
+++ b/examples/workflow-editor-v2/src/nodes/index.ts
@@ -1,0 +1,22 @@
+import { NodeTypes } from "@xyflow/react";
+import { triggerNodeFactory } from "./TriggerNode";
+import { BlankNode } from "./BlankNode";
+import {
+  EmailNode,
+  DelayNode,
+  AgentNode,
+  McpNode,
+  MemoryNode,
+  StorageNode,
+} from "./ActionBaseNode";
+
+export const nodeTypes: NodeTypes = {
+  trigger: triggerNodeFactory,
+  blank: BlankNode,
+  email: EmailNode,
+  delay: DelayNode,
+  agent: AgentNode,
+  mcp: McpNode,
+  memory: MemoryNode,
+  storage: StorageNode,
+};

--- a/examples/workflow-editor-v2/src/types/actions.ts
+++ b/examples/workflow-editor-v2/src/types/actions.ts
@@ -1,0 +1,73 @@
+import { v4 as uuid } from "uuid";
+
+export type ActionKind = "email" | "delay" | "agent" | "webhook";
+
+export interface WorkflowActionBase {
+  id: string;
+  kind: ActionKind;
+  name?: string;
+  description?: string;
+}
+
+export interface EmailAction extends WorkflowActionBase {
+  kind: "email";
+  to: string;
+  subject: string;
+  body: string;
+}
+
+export interface DelayAction extends WorkflowActionBase {
+  kind: "delay";
+  durationMs: number;
+}
+
+// ── Agent-specific domain objects ────────────────────────────────────────────
+export interface MCP {
+  id: string;
+  name: string;
+  endpoint: string;
+  transport: "stdio" | "sse" | "streamable-http";
+  envs: Record<string, any>;
+  args: string[];
+}
+
+export interface Memory {
+  id: string;
+  name: string;
+  conversationHistory: number;
+  workingMemory: any; // JSON blob
+}
+
+export interface Storage {
+  id: string;
+  type: "postgres"; // currently fixed
+  endpoint: string;
+  port: number;
+  user: string;
+  password: string;
+  database: string;
+}
+
+export interface AgentAction extends WorkflowActionBase {
+  kind: "agent";
+  instructions: string;
+  inputs: {
+    mcps: MCP[];
+    memory: Memory;
+    storage: Storage;
+  };
+}
+
+export type AnyAction = EmailAction | DelayAction | AgentAction;
+
+// Factory helpers (optional convenience)
+export const createEmailAction = (
+  init?: Partial<EmailAction>
+): EmailAction => ({
+  id: uuid(),
+  kind: "email",
+  to: "",
+  subject: "",
+  body: "",
+  ...init,
+});

--- a/examples/workflow-editor-v2/src/types/index.ts
+++ b/examples/workflow-editor-v2/src/types/index.ts
@@ -1,0 +1,2 @@
+export * from './actions';
+export * from './workflow';

--- a/examples/workflow-editor-v2/src/types/workflow.ts
+++ b/examples/workflow-editor-v2/src/types/workflow.ts
@@ -1,0 +1,14 @@
+import { AnyAction } from "./actions";
+
+export interface WorkflowEdge {
+  id: string;
+  source: string;
+  target: string;
+}
+
+export interface Workflow {
+  id: string;
+  name: string;
+  actions: AnyAction[];
+  edges: WorkflowEdge[]; // optional manual overrides – auto edges generated in UI
+}

--- a/examples/workflow-editor-v2/src/utils/layout.ts
+++ b/examples/workflow-editor-v2/src/utils/layout.ts
@@ -1,0 +1,111 @@
+import { useMemo } from 'react';
+import Dagre from '@dagrejs/dagre';
+import { Node, Edge, Rect } from '@xyflow/react';
+import { Direction } from '../components/Editor';
+
+type LayoutArgs = {
+  nodes: Node[];
+  edges: Edge[];
+  width: number;
+  height: number;
+  direction: Direction;
+  setNodes: (nodes: Node[]) => void;
+  setEdges: (edges: Edge[]) => void;
+  nodesInitialized: boolean;
+  defaultNodeMeasure: { width: number; height: number } | undefined;
+};
+
+export const useLayout = (args: LayoutArgs): Rect => {
+  const {
+    nodes,
+    edges,
+    width,
+    height,
+    direction,
+    setNodes,
+    setEdges,
+    nodesInitialized,
+    defaultNodeMeasure,
+  } = args;
+
+  return useMemo(() => {
+    if (!nodesInitialized) {
+      return { x: 0, y: 0, width: 0, height: 0 };
+    }
+
+    const nodesWithMeasures = nodes.map((node) => {
+      if (!node.measured) {
+        return { ...node, measured: defaultNodeMeasure };
+      }
+      return node;
+    });
+
+    const { nodes: newNodes, edges: newEdges, rect } = getLayoutedElements(
+      nodesWithMeasures,
+      edges,
+      direction
+    );
+
+    setNodes(newNodes);
+    setEdges(newEdges);
+
+    return rect;
+  }, [JSON.stringify(nodes), JSON.stringify(edges), width, height, direction, nodesInitialized]);
+};
+
+export const getLayoutedElements = (
+  nodes: Node[],
+  edges: Edge[],
+  direction: Direction
+): { nodes: Node[]; edges: Edge[]; rect: Rect } => {
+  const g = new Dagre.graphlib.Graph({ directed: true }).setDefaultEdgeLabel(() => ({}));
+
+  let nodePadding = 60;
+  if (direction === 'right') {
+    nodePadding += 50;
+  }
+
+  g.setGraph({
+    nodesep: 100,
+    ranksep: nodePadding,
+    rankdir: direction === 'down' ? 'TB' : 'LR',
+  });
+
+  nodes.forEach((node) =>
+    g.setNode(node.id, {
+      width: node.measured?.width ?? 0,
+      height: node.measured?.height ?? 0,
+      node,
+    })
+  );
+
+  edges.forEach((edge) => g.setEdge(edge.source, edge.target));
+
+  Dagre.layout(g);
+
+  const layout = g.nodes().map((nodeID) => {
+    const dagreNode = g.node(nodeID);
+    const node = (dagreNode as any).node as Node;
+
+    const x = dagreNode.x - (node.measured?.width ?? 0) / 2;
+    const y = dagreNode.y - (node.measured?.height ?? 0) / 2;
+
+    return { ...node, position: { x, y } };
+  });
+
+  const minX = Math.min(...layout.map((node) => node.position.x));
+  const minY = Math.min(...layout.map((node) => node.position.y));
+  const maxX = Math.max(...layout.map((node) => node.position.x + (node.measured?.width ?? 0)));
+  const maxY = Math.max(...layout.map((node) => node.position.y + (node.measured?.height ?? 0)));
+
+  return {
+    nodes: layout,
+    edges,
+    rect: {
+      x: minX,
+      y: minY,
+      width: maxX - minX,
+      height: maxY - minY,
+    },
+  };
+};

--- a/examples/workflow-editor-v2/src/utils/parseWorkflow.ts
+++ b/examples/workflow-editor-v2/src/utils/parseWorkflow.ts
@@ -1,0 +1,83 @@
+import { Edge, Node } from "@xyflow/react";
+import { v4 as uuid } from "uuid";
+import {
+  AnyAction,
+  AgentAction,
+  MCP,
+  Memory,
+  Storage,
+} from "../types/actions";
+import { Workflow } from "../types/workflow";
+import { getLayoutedElements } from "./layout";
+
+export const buildGraph = (
+  workflow: Workflow,
+  direction: "down" | "right" = "down"
+) => {
+  const nodes: Node[] = [];
+  const edges: Edge[] = [];
+
+  // Trigger
+  nodes.push({
+    id: "trigger",
+    type: "trigger",
+    data: { trigger: workflow.id },
+    position: { x: 0, y: 0 },
+  });
+
+  workflow.actions.forEach((action: AnyAction, idx) => {
+    const baseId = action.id;
+
+    // Base action node
+    nodes.push({
+      id: baseId,
+      type: action.kind,
+      data: { action },
+      position: { x: 0, y: 0 },
+    });
+
+    // Linear edge chain
+    const src = idx === 0 ? "trigger" : workflow.actions[idx - 1].id;
+    edges.push({ id: uuid(), source: src, target: baseId, type: "smoothstep" });
+
+    // ── Agent fan-out ───────────────────────────────────────────────────────
+    if (action.kind === "agent") {
+      const agent = action as AgentAction;
+
+      // 1) MCPs
+      agent.inputs.mcps.forEach((mcp: MCP) => {
+        nodes.push({
+          id: mcp.id,
+          type: "mcp",
+          data: { mcp, parentId: baseId },
+          position: { x: 0, y: 0 },
+        });
+        edges.push({ id: uuid(), source: baseId, target: mcp.id, type: "smoothstep" });
+      });
+
+      // 2) Memory
+      const mem = agent.inputs.memory as Memory;
+      const memId = mem.id;
+      nodes.push({
+        id: memId,
+        type: "memory",
+        data: { memory: mem, parentId: baseId },
+        position: { x: 0, y: 0 },
+      });
+      edges.push({ id: uuid(), source: baseId, target: memId, type: "smoothstep" });
+
+      // 3) Storage
+      const stg = agent.inputs.storage as Storage;
+      const stgId = stg.id;
+      nodes.push({
+        id: stgId,
+        type: "storage",
+        data: { storage: stg, parentId: memId },
+        position: { x: 0, y: 0 },
+      });
+      edges.push({ id: uuid(), source: memId, target: stgId, type: "smoothstep" });
+    }
+  });
+
+  return getLayoutedElements(nodes, edges, direction);
+};


### PR DESCRIPTION
## Summary
- add Memory and Storage node types with agent fan-out logic
- create ReactFlow editor example demonstrating automatic edges

## Testing
- `pnpm test` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_684fbdf11fd483298e8bc97d4d1cc9d1