### PR TITLE
Fix nodeTypes wrappers for xyflow example

### DIFF
--- a/examples/workflow-editor-v2/src/nodes/index.ts
+++ b/examples/workflow-editor-v2/src/nodes/index.ts
@@ -1,4 +1,4 @@
-import { NodeTypes } from "@xyflow/react";
+import type { NodeTypes, NodeProps } from "@xyflow/react";
 import { triggerNodeFactory } from "./TriggerNode";
 import { BlankNode } from "./BlankNode";
 import {
@@ -13,10 +13,12 @@ import {
 export const nodeTypes: NodeTypes = {
   trigger: triggerNodeFactory,
   blank: BlankNode,
-  email: EmailNode,
-  delay: DelayNode,
-  agent: AgentNode,
-  mcp: McpNode,
-  memory: MemoryNode,
-  storage: StorageNode,
+  email: ({ data }: NodeProps) => <EmailNode action={(data as any).action} />,
+  delay: ({ data }: NodeProps) => <DelayNode action={(data as any).action} />,
+  agent: ({ data }: NodeProps) => <AgentNode action={(data as any).action} />,
+  mcp: ({ data }: NodeProps) => <McpNode mcp={(data as any).mcp} />,
+  memory: ({ data }: NodeProps) => <MemoryNode memory={(data as any).memory} />,
+  storage: ({ data }: NodeProps) => (
+    <StorageNode storage={(data as any).storage} />
+  ),
 };


### PR DESCRIPTION
## Summary
- align node component typing with React Flow 12 in `nodeTypes`

## Testing
- `pnpm test` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684fc40e14288329821f57025caf3f59